### PR TITLE
Matts/one client testing

### DIFF
--- a/cmd/doppler-api/main.go
+++ b/cmd/doppler-api/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 
-	go liveupdate.StartWebsocket()
+	go liveupdate.InitWebsockets()
 	liveupdate.Consume()
 
 	//get CB config values from .env file

--- a/cmd/doppler-api/main.go
+++ b/cmd/doppler-api/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	//cb "github.com/acstech/doppler-api/internal/couchbase"
 	fx "github.com/acstech/doppler-api/internal/influx"
 	client "github.com/influxdata/influxdb/client/v2"
 	"github.com/joho/godotenv"
@@ -21,12 +20,6 @@ func main() {
 		panic(err)
 	}
 	cbCon := os.Getenv("COUCHBASE_CONN")
-
-	go liveupdate.StartWebsocket(cbCon)
-	liveupdate.Consume()
-
-	//ensure that the eventID exists
-	//cbConn.EventEnsure("test2", "")
 
 	// creates influx client
 	c, err := client.NewHTTPClient(client.HTTPConfig{
@@ -55,4 +48,8 @@ func main() {
 	}
 
 	fmt.Println("Client exists and the eventID has been ensured.")
+
+	//intialize websocket management and kafka consume
+	go liveupdate.InitWebsockets(cbCon)
+	liveupdate.Consume()
 }

--- a/cmd/doppler-api/main.go
+++ b/cmd/doppler-api/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"net/http"
 	"os"
 
 	fx "github.com/acstech/doppler-api/internal/influx"
@@ -53,9 +51,5 @@ func main() {
 
 	//intialize websocket management and kafka consume
 	go liveupdate.InitWebsockets(cbCon)
-
-	//listen for calls to server
-	if err := http.ListenAndServe(":8000", nil); err != nil {
-		log.Fatal(err)
-	}
+	liveupdate.Consume()
 }

--- a/internal/liveupdate/liveupdate.go
+++ b/internal/liveupdate/liveupdate.go
@@ -3,12 +3,13 @@ package liveupdate
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 
 	"github.com/Shopify/sarama"
+	"github.com/acstech/doppler-api/internal/couchbase"
 	"github.com/gorilla/websocket"
 )
 
@@ -18,16 +19,25 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+var cbConn *couchbase.Couchbase
 var clientConnections map[string]map[*ConnWithParameters]struct{}
+var mutex = &sync.RWMutex{}
 var count int = 0
 
 type ConnWithParameters struct {
-	ws            *websocket.Conn
-	clientID      string
-	filterSetting string
+	ws            *websocket.Conn     //keeps up with connection identifier
+	clientID      string              //the clientID associated with this connection
+	filterSetting map[string]struct{} //a map of the events that the client currently wants to see
 }
 
-type Point struct {
+type msg struct {
+	ClientID      string
+	FilterSetting []string `json:"filterSetting,omitempty"`
+	//startTime <type> `json:"startTime, omitempty"`
+	//endTime <type> `json:"endTime, omitempty"`
+}
+
+type KafkaData struct {
 	Latitude  string `json:"lat"`
 	Longitude string `json:"lng"`
 	Count     string `json:"count"`
@@ -37,16 +47,26 @@ type Point struct {
 }
 
 // Initialize listening for websocket requests
-func InitWebsockets() {
+func InitWebsockets(cbConnection string) {
+	//create CB connection
+	cbConn = &couchbase.Couchbase{Doc: &couchbase.Doc{}}
+	cbConn.ConnectToCB(cbConnection)
+	fmt.Println("Connected to Couchbase")
+	fmt.Println()
+
+	//start kafka consume
+	go Consume()
+
+	//server index
+	http.HandleFunc("/", serveIndex)
+
 	//intialize connection management
 	clientConnections = make(map[string]map[*ConnWithParameters]struct{})
 	fmt.Println("Ready to Receive Websocket Requests")
+	fmt.Println()
+
 	//handle any websocket requests
 	http.HandleFunc("/receive/ws", createWS)
-	//listen for calls to server
-	if err := http.ListenAndServe(":8000", nil); err != nil {
-		log.Fatal(err)
-	}
 }
 
 // Get a request for a point, then send coordinates back to front end
@@ -55,16 +75,19 @@ func createWS(w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		fmt.Println("Connection Upgrade Error")
+		fmt.Println()
 		fmt.Println(err)
 		ws.Close() //close the connection just in case
 		return
 	}
-	fmt.Println("Connection Upgraded")
+	fmt.Println("NEW CONNECTION: Connection Upgraded")
+	fmt.Println()
+
 	//Initialize conn with parameters
 	conn := &ConnWithParameters{
 		ws:            ws,
 		clientID:      "",
-		filterSetting: "",
+		filterSetting: make(map[string]struct{}),
 	}
 
 	//now listen for messages for this created websocket
@@ -77,34 +100,85 @@ func readWS(conn *ConnWithParameters) {
 	// Function to read any messages that are received
 	for {
 		//read messages from client
-		_, msg, err := conn.ws.ReadMessage()
+		_, msgBytes, err := conn.ws.ReadMessage()
+		conn.ws.WriteJSON("got message")
 		//check if client closed connection
 		if err != nil {
 			fmt.Println("Connection Closed by Client")
-			conn.ws.Close()
+			//REMOVE FROM MAP
+			mutex.Lock()
+			delete(clientConnections[conn.clientID], conn)
+			fmt.Println(clientConnections)
+			mutex.Unlock()
 			return
 		}
-		// if websocket hasnt been intialized
-		if connected == false {
-			clientConnections[msg.clientID]
+		var message msg
+		//unmarshal (convert bytes to msg struct)
+		if err := json.Unmarshal(msgBytes, &message); err != nil {
+			fmt.Println("unmarshal error")
+			fmt.Println(err)
 		}
+		fmt.Println("Message Received from ", message.ClientID, " on connection ", conn)
+		fmt.Println("json msg: ", message)
+		fmt.Println()
+
+		// if websocket hasnt been added to clientConnections map
+		if connected == false {
+			//update conn with new parameters
+			conn.clientID = message.ClientID
+			//UPDATE FILTERSETTINGS
+			conn.filterSetting = make(map[string]struct{})
+			for _, event := range message.FilterSetting {
+				conn.filterSetting[event] = struct{}{}
+			}
+			fmt.Println("filter setting: ", conn.filterSetting)
+
+			//check if client is already connected on another websocket
+			//if client has not been connected, create new connection map
+			mutex.RLock()
+			if _, contains := clientConnections[message.ClientID]; !contains {
+				clientConnections[message.ClientID] = make(map[*ConnWithParameters]struct{})
+			}
+			mutex.Unlock()
+			//add conn to map
+			mutex.Lock()
+			clientConnections[message.ClientID][conn] = struct{}{}
+			fmt.Println("added client", clientConnections)
+			mutex.Unlock()
+			fmt.Println()
+			connected = true
+
+			//CHECK COUCHBASE
+			//check if client exists in couchbase
+			if cbConn.ClientExists(message.ClientID) {
+				//query couchbase for client's events
+				clientEvents := cbConn.Doc.Events
+				conn.ws.WriteJSON(clientEvents)
+			} else {
+				//if clientID does not exist in couchbase
+				conn.ws.WriteMessage(1, []byte("ClientID not found"))
+			}
+
+			//continue to next for loop iteration, skipping updating filters
+			continue
+		}
+		//UPDATE FILTERS
+		conn.filterSetting = make(map[string]struct{})
+		for _, event := range message.FilterSetting {
+			conn.filterSetting[event] = struct{}{}
+		}
+
+		fmt.Println("filter setting: ", conn.filterSetting)
 	}
 }
 
-// Send points to front end
-func SendPoint(point Point, cs *websocket.Conn) {
-	for _, conn := range Websockets {
-		//conn.WriteJSON(point)
-		conn.addr.WriteJSON(Point{
-			Longitude: point.Longitude,
-			Latitude:  point.Latitude,
-			Count:     "3",
-		})
-	}
+func serveIndex(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, "index.html")
 }
 
 // Consume messages from queue
 func Consume() {
+	fmt.Println("Kafka Consume Started")
 	// Create a new configuration instance
 	config := sarama.NewConfig()
 
@@ -148,25 +222,26 @@ func Consume() {
 				fmt.Println(err)
 			// Print consumer messages
 			case msg := <-consumer.Messages():
-				//fmt.Println(string(msg.Value))
-				var point Point
-				json.Unmarshal(msg.Value, &point)
+				// fmt.Println(string(msg.Value))
+				var kafkaData KafkaData
+				json.Unmarshal(msg.Value, &kafkaData)
 
-				//fmt.Println("Lat: " + point.Latitude + " Lng: " + point.Longitude)
+				// fmt.Println("Lat: " + kafkaData.Latitude + " Lng: " + kafkaData.Longitude)
 				// Check if ClientID exists
-				if _, contains := Websockets[point.Client]; contains {
-					// If it does create an instance of ConnectionStruct
-					cs := Websockets[point.Client]
-
-					if cs.filterSetting == "all" {
-						point.Count = "3"
-						SendPoint(point, cs.addr)
-						// Match filter setting to point event
-					} else if cs.filterSetting == point.Event {
-						point.Count = "3"
-						SendPoint(point, cs.addr)
+				mutex.RLock()
+				if _, contains := clientConnections[kafkaData.ClientID]; contains {
+					// If client is connected, get map of connections
+					clientConnections := clientConnections[kafkaData.ClientID]
+					//iterate over client connections
+					for conn, _ := range clientConnections {
+						//if connection filter has KafkaData eventID, send data
+						if _, hasEvent := conn.filterSetting[kafkaData.EventID]; hasEvent {
+							conn.ws.WriteJSON(kafkaData)
+							//fmt.Println("Send Data to ", conn.clientID)
+						}
 					}
 				}
+				mutex.Unlock()
 			// Service interruption
 			case <-signals:
 				fmt.Println("Interrupt detected")
@@ -179,8 +254,3 @@ func Consume() {
 	<-doneCh
 	fmt.Println("Consumption closed")
 }
-
-// func main() {
-// 	go StartWebsocket()
-// 	Consume()
-// }

--- a/internal/liveupdate/liveupdate.go
+++ b/internal/liveupdate/liveupdate.go
@@ -3,120 +3,186 @@ package liveupdate
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
+	"sync"
 
 	"github.com/Shopify/sarama"
 	"github.com/acstech/doppler-api/internal/couchbase"
 	"github.com/gorilla/websocket"
 )
 
-// Force origin policy to be true in order to avoid 403 error
+//upgrader var used to set parameters for websocket connections
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		return true
 	},
 }
 
-// Manage clients, connections, filters of those connections
-var Websockets = make(map[string]map[*Connection]struct{})
-var count int = 0
-var cbConn *couchbase.Couchbase
+var cbConn *couchbase.Couchbase                                   //used to hold couchbase connection
+var clientConnections map[string]map[*ConnWithParameters]struct{} //map used as connection hub, keeps up with clients and their respective connections and each connections settings
+var mutex = &sync.Mutex{}                                         //mutex used for concurrent reading and writing
+var count int = 0                                                 //hard coded weight
 
-// Connection has a websocket connection and a filter setting
-type Connection struct {
-	addr          *websocket.Conn
-	filterSetting string
+//used to add parameters to a gorilla's websocket.Conn
+type ConnWithParameters struct {
+	ws       *websocket.Conn     //keeps up with connection identifier
+	clientID string              //the clientID associated with this connection
+	filter   map[string]struct{} //a map of the events that the client currently wants to see
+	// allFilters map[string]struct{} //a map of all the events that the client has available
 }
 
-var connection Connection
+//JSON format messages from client
+type msg struct {
+	ClientID string   `json:"clientID,omitempty"`
+	Filter   []string `json:"Filter,omitempty"`
+	//startTime <type> `json:"startTime, omitempty"`
+	//endTime <type> `json:"endTime, omitempty"`
+}
 
-// Data to be sent to front end so it can be mapped
-type Point struct {
-	Latitude  string `json:"lat,omitempty"`
-	Longitude string `json:"lng,omitempty"`
-	// Number of times this event has happened
-	Count  string `json:"count,omitempty"`
-	Client string `json:"clientID,omitempty"`
-	Event  string `json:"eventID,omitempty"`
+//JSON format messages from Kafka
+type KafkaData struct {
+	Latitude  string `json:"lat"`
+	Longitude string `json:"lng"`
+	Count     string `json:"count"`
+	ClientID  string `json:"clientID"`
+	EventID   string `json:"eventID"`
 	// Insert time eventually
 }
 
-// Start a websocket connection for client
-// cbCon is the couchbase connection string
-func StartWebsocket(cbCon string) {
+// Initialize listening for websocket requests
+func InitWebsockets(cbConnection string) {
 	//create CB connection
 	cbConn = &couchbase.Couchbase{Doc: &couchbase.Doc{}}
-	// Connect to couchbase
-	cbConn.ConnectToCB(cbCon)
-	http.HandleFunc("/v3/ws", dot)
-	Websockets = make(map[string]map[*Connection]struct{})
-	fmt.Println("websocket running!")
-	http.ListenAndServe(":8000", nil)
+	cbConn.ConnectToCB(cbConnection)
+	fmt.Println("Connected to Couchbase")
+	fmt.Println()
+
+	//intialize connection management
+	clientConnections = make(map[string]map[*ConnWithParameters]struct{})
+	fmt.Println("Ready to Receive Websocket Requests")
+	fmt.Println()
+
+	//handle any websocket requests
+	http.HandleFunc("/receive/ws", createWS)
+
+	//listen for calls to server
+	if err := http.ListenAndServe(":8000", nil); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // Get a request for a point, then send coordinates back to front end
-func dot(w http.ResponseWriter, r *http.Request) {
+func createWS(w http.ResponseWriter, r *http.Request) {
 	// Upgrade HTTP server connection to the WebSocket protocol
-	var conn, err = upgrader.Upgrade(w, r, nil)
+	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
+		fmt.Println("Connection Upgrade Error")
 		fmt.Println(err)
+		ws.Close() //close the connection just in case
 		return
 	}
+	fmt.Println("NEW CONNECTION: Connection Upgraded, waiting for ClientID")
 
-	// Function to read any messages that are received
-	go func(conn *websocket.Conn) {
-		for {
-			_, msg, err := conn.ReadMessage()
-			if err != nil {
-				conn.Close()
-				return
-			}
+	//Initialize conn with parameters
+	conn := &ConnWithParameters{
+		ws:       ws,
+		clientID: "",
+		filter:   make(map[string]struct{}),
+	}
 
-			if strings.Contains(string(msg), "clientID") {
-				var point Point
-				// Unmarshal read message into point object
-				err := json.Unmarshal(msg, &point)
-				if err != nil {
-					panic(err)
-				}
-				// See if client id exists by running couchbase query
-				if cbConn.ClientExists(point.Client) {
-					// Pass client id as a key value
-					Websockets[point.Client] = make(map[*Connection]struct{})
-					err = conn.WriteJSON(cbConn.Doc.Events)
-					if err != nil {
-						panic(err)
-					}
-					fmt.Println("connected")
-				}
-			} else {
-				conn.WriteMessage(1, msg)
-			}
-		}
-	}(conn)
-
-	// Websockets[strconv.Itoa(count)] = conn
-	// count++
-	// fmt.Println(count)
+	//now listen for messages for this created websocket
+	go readWS(conn)
 }
 
-// Send points to front end
-// func SendPoint(point Point, connection Connection) {
-// 	for _, conn := range Websockets {
-// 		//conn.WriteJSON(point)
-// 		connection.addr.WriteJSON(Point{
-// 			Longitude: point.Longitude,
-// 			Latitude:  point.Latitude,
-// 			Count:     "3",
-// 		})
-// 	}
-// }
+func readWS(conn *ConnWithParameters) {
+	defer conn.ws.Close()
+
+	//boolean used to keep up if this websocket has been connected
+	connected := false
+
+	// Function to read any messages that are received
+	for {
+		//read messages from client
+		_, msgBytes, err := conn.ws.ReadMessage()
+		//check if client closed connection
+		if err != nil {
+			fmt.Println("Connection Closed by Client")
+			//REMOVE FROM MAP
+			mutex.Lock()
+			delete(clientConnections[conn.clientID], conn)
+			//check if client has any remaining connections, if so, delete client
+			if len(clientConnections[conn.clientID]) == 0 {
+				delete(clientConnections, conn.clientID)
+			}
+			fmt.Println("Removed Conn: ", clientConnections)
+			mutex.Unlock()
+			return
+		}
+		//declare message that will hold client message data
+		var message msg
+		//unmarshal (convert bytes to msg struct)
+		if err := json.Unmarshal(msgBytes, &message); err != nil {
+			fmt.Println("unmarshal error")
+			fmt.Println(err)
+		}
+
+		//WEBSOCKET MANAGEMENT
+		// if websocket hasnt been added to clientConnections map
+		if !connected {
+			//update conn with new parameters
+			//add clientID to connection
+			conn.clientID = message.ClientID
+
+			//check if client is already connected on another websocket
+			//if client has not been connected, create new connection map
+			mutex.Lock()
+			if _, contains := clientConnections[message.ClientID]; !contains {
+				clientConnections[message.ClientID] = make(map[*ConnWithParameters]struct{})
+			}
+			mutex.Unlock()
+			//add conn to map
+			mutex.Lock()
+			clientConnections[message.ClientID][conn] = struct{}{}
+			fmt.Println("Added Conn", clientConnections)
+			mutex.Unlock()
+			fmt.Println()
+			//update connected to true
+			connected = true
+
+			//CHECK COUCHBASE
+			//check if client exists in couchbase
+			if cbConn.ClientExists(message.ClientID) {
+				//query couchbase for client's events
+				clientEvents := cbConn.Doc.Events
+				//add filters to connection
+				for _, event := range clientEvents {
+					conn.filter[event] = struct{}{}
+				}
+				//send event options to client
+				conn.ws.WriteJSON(clientEvents)
+			} else {
+				//if clientID does not exist in couchbase
+				conn.ws.WriteMessage(1, []byte("Couchbase Error: ClientID not found"))
+			}
+			//continue to next for loop iteration, skipping updating filters
+			continue
+		}
+
+		//UPDATE FILTERS
+		conn.filter = make(map[string]struct{}) //reinitialize filters because receiving whole array of filters from client
+		//iterate through client message filter array and add the elements to the connection filter slice
+		for _, event := range message.Filter {
+			conn.filter[event] = struct{}{}
+		}
+	}
+}
 
 // Consume messages from queue
 func Consume() {
+	fmt.Println("Kafka Consume Started")
 	// Create a new configuration instance
 	config := sarama.NewConfig()
 
@@ -153,6 +219,7 @@ func Consume() {
 	// Signal to finish
 	doneCh := make(chan struct{})
 	go func() {
+	Loop:
 		for {
 			select {
 			// In case of error
@@ -160,29 +227,30 @@ func Consume() {
 				fmt.Println(err)
 			// Print consumer messages
 			case msg := <-consumer.Messages():
-				//fmt.Println(string(msg.Value))
-				var point Point
-				json.Unmarshal(msg.Value, &point)
+				// fmt.Println("Got data ", string(msg.Value))
+				var kafkaData KafkaData
+				json.Unmarshal(msg.Value, &kafkaData)
 
-				//fmt.Println("Lat: " + point.Latitude + " Lng: " + point.Longitude)
 				// Check if ClientID exists
-				// if _, contains := Websockets[point.Client]; contains {
-				// 	// If it does create an instance of ConnectionStruct
-				// 	cs := Websockets[point.Client]
-
-				// 	if cs.filterSetting == "all" {
-				// 		point.Count = "3"
-				// 		SendPoint(point, cs.addr)
-				// 		// Match filter setting to point event
-				// 	} else if cs.filterSetting == point.Event {
-				// 		point.Count = "3"
-				// 		SendPoint(point, cs.addr)
-				// 	}
-				// }
+				mutex.Lock()
+				if _, contains := clientConnections[kafkaData.ClientID]; contains {
+					// If client is connected, get map of connections
+					clientConnections := clientConnections[kafkaData.ClientID]
+					//iterate over client connections
+					for conn, _ := range clientConnections {
+						//TODO Update allFilters if find a new filter and send new filter options to front end
+						//if connection filter has KafkaData eventID, send data
+						if _, hasEvent := conn.filter[kafkaData.EventID]; hasEvent {
+							conn.ws.WriteJSON(kafkaData)
+						}
+					}
+				}
+				mutex.Unlock()
 			// Service interruption
 			case <-signals:
 				fmt.Println("Interrupt detected")
 				doneCh <- struct{}{}
+				break Loop
 			}
 		}
 	}()
@@ -191,8 +259,3 @@ func Consume() {
 	<-doneCh
 	fmt.Println("Consumption closed")
 }
-
-// func main() {
-// 	go StartWebsocket()
-// 	Consume()
-// }

--- a/internal/liveupdate/liveupdate.go
+++ b/internal/liveupdate/liveupdate.go
@@ -3,40 +3,46 @@ package liveupdate
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 
 	"github.com/Shopify/sarama"
 	"github.com/acstech/doppler-api/internal/couchbase"
 	"github.com/gorilla/websocket"
 )
 
+//upgrader var used to set parameters for websocket connections
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		return true
 	},
 }
 
-var cbConn *couchbase.Couchbase
-var clientConnections map[string]map[*ConnWithParameters]struct{}
-
-// var // = &sync.RW//{}
+var cbConn *couchbase.Couchbase                                   //used to hold couchbase connection
+var clientConnections map[string]map[*ConnWithParameters]struct{} //map used as connection hub, keeps up with clients and their respective connections and each connections settings
+var mutex = &sync.Mutex{}
 var count int = 0
 
+//used to add parameters to a gorilla's websocket.Conn
 type ConnWithParameters struct {
-	ws            *websocket.Conn     //keeps up with connection identifier
-	clientID      string              //the clientID associated with this connection
-	filterSetting map[string]struct{} //a map of the events that the client currently wants to see
+	ws       *websocket.Conn     //keeps up with connection identifier
+	clientID string              //the clientID associated with this connection
+	filter   map[string]struct{} //a map of the events that the client currently wants to see
+	// allFilters map[string]struct{} //a map of all the events that the client has available
 }
 
+//JSON format messages from client
 type msg struct {
-	ClientID      string
-	FilterSetting []string `json:"filterSetting,omitempty"`
+	ClientID string   `json:"clientID,omitempty"`
+	Filter   []string `json:"Filter,omitempty"`
 	//startTime <type> `json:"startTime, omitempty"`
 	//endTime <type> `json:"endTime, omitempty"`
 }
 
+//JSON format messages from Kafka
 type KafkaData struct {
 	Latitude  string `json:"lat"`
 	Longitude string `json:"lng"`
@@ -55,7 +61,7 @@ func InitWebsockets(cbConnection string) {
 	fmt.Println()
 
 	//start kafka consume
-	go Consume()
+	// go Consume()
 
 	//server index
 	// http.HandleFunc("/", serveIndex)
@@ -67,6 +73,11 @@ func InitWebsockets(cbConnection string) {
 
 	//handle any websocket requests
 	http.HandleFunc("/receive/ws", createWS)
+
+	//listen for calls to server
+	if err := http.ListenAndServe(":8000", nil); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // Get a request for a point, then send coordinates back to front end
@@ -75,19 +86,17 @@ func createWS(w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		fmt.Println("Connection Upgrade Error")
-		fmt.Println()
 		fmt.Println(err)
 		ws.Close() //close the connection just in case
 		return
 	}
-	fmt.Println("NEW CONNECTION: Connection Upgraded")
-	fmt.Println()
+	fmt.Println("NEW CONNECTION: Connection Upgraded, waiting for ClientID")
 
 	//Initialize conn with parameters
 	conn := &ConnWithParameters{
-		ws:            ws,
-		clientID:      "",
-		filterSetting: make(map[string]struct{}),
+		ws:       ws,
+		clientID: "",
+		filter:   make(map[string]struct{}),
 	}
 
 	//now listen for messages for this created websocket
@@ -96,80 +105,99 @@ func createWS(w http.ResponseWriter, r *http.Request) {
 
 func readWS(conn *ConnWithParameters) {
 	defer conn.ws.Close()
+
+	//boolean used to keep up if this websocket has been connected
 	connected := false
+
 	// Function to read any messages that are received
+	// Stop process if connection is interrupted
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	doneCh := make(chan struct{})
+Loop:
 	for {
 		//read messages from client
 		_, msgBytes, err := conn.ws.ReadMessage()
-		conn.ws.WriteJSON("got message")
 		//check if client closed connection
 		if err != nil {
 			fmt.Println("Connection Closed by Client")
 			//REMOVE FROM MAP
-			//.Lock()
+			mutex.Lock()
 			delete(clientConnections[conn.clientID], conn)
-			fmt.Println(clientConnections)
-			//.Unlock()
+			//check if client has any remaining connections, if so, delete client
+			if len(clientConnections[conn.clientID]) == 0 {
+				delete(clientConnections, conn.clientID)
+			}
+			fmt.Println("Removed Conn: ", clientConnections)
+			mutex.Unlock()
 			return
 		}
+		//declare message that will hold client message data
 		var message msg
 		//unmarshal (convert bytes to msg struct)
 		if err := json.Unmarshal(msgBytes, &message); err != nil {
 			fmt.Println("unmarshal error")
 			fmt.Println(err)
 		}
-		fmt.Println("Message Received from ", message.ClientID, " on connection ", conn)
-		fmt.Println("json msg: ", message)
-		fmt.Println()
 
+		//WEBSOCKET MANAGEMENT
 		// if websocket hasnt been added to clientConnections map
-		if connected == false {
+		if !connected {
 			//update conn with new parameters
+			//add clientID to connection
 			conn.clientID = message.ClientID
-			//UPDATE FILTERSETTINGS
-			conn.filterSetting = make(map[string]struct{})
-			for _, event := range message.FilterSetting {
-				conn.filterSetting[event] = struct{}{}
-			}
-			fmt.Println("filter setting: ", conn.filterSetting)
 
 			//check if client is already connected on another websocket
 			//if client has not been connected, create new connection map
-			//.RLock()
+			mutex.Lock()
 			if _, contains := clientConnections[message.ClientID]; !contains {
 				clientConnections[message.ClientID] = make(map[*ConnWithParameters]struct{})
 			}
-			//.Unlock()
+			mutex.Unlock()
 			//add conn to map
-			//.Lock()
+			mutex.Lock()
 			clientConnections[message.ClientID][conn] = struct{}{}
-			fmt.Println("added client", clientConnections)
-			//.Unlock()
+			fmt.Println("Added Conn", clientConnections)
+			mutex.Unlock()
 			fmt.Println()
+			//update connected to true
 			connected = true
 
 			//CHECK COUCHBASE
 			//check if client exists in couchbase
 			if cbConn.ClientExists(message.ClientID) {
 				//query couchbase for client's events
-				// clientEvents := cbConn.Doc.Events
-				// conn.ws.WriteJSON(clientEvents)
+				clientEvents := cbConn.Doc.Events
+				//add filters to connection
+				for _, event := range clientEvents {
+					conn.filter[event] = struct{}{}
+				}
+				//send event options to client
+				conn.ws.WriteJSON(clientEvents)
 			} else {
 				//if clientID does not exist in couchbase
 				conn.ws.WriteMessage(1, []byte("ClientID not found"))
 			}
-
 			//continue to next for loop iteration, skipping updating filters
 			continue
 		}
-		//UPDATE FILTERS
-		conn.filterSetting = make(map[string]struct{})
-		for _, event := range message.FilterSetting {
-			conn.filterSetting[event] = struct{}{}
-		}
 
-		fmt.Println("filter setting: ", conn.filterSetting)
+		//UPDATE FILTERS
+		conn.filter = make(map[string]struct{})
+		for _, event := range message.Filter {
+			conn.filter[event] = struct{}{}
+		}
+		select {
+		case <-signals:
+			fmt.Println("Websocket Interrupt detected")
+			doneCh <- struct{}{}
+			break Loop
+		default:
+			continue
+		}
 	}
+	<-doneCh
+	fmt.Println("Consumption closed")
 }
 
 func serveIndex(w http.ResponseWriter, r *http.Request) {
@@ -215,6 +243,7 @@ func Consume() {
 	// Signal to finish
 	doneCh := make(chan struct{})
 	go func() {
+	Loop:
 		for {
 			select {
 			// In case of error
@@ -222,32 +251,30 @@ func Consume() {
 				fmt.Println(err)
 			// Print consumer messages
 			case msg := <-consumer.Messages():
-				// fmt.Println(string(msg.Value))
+				// fmt.Println("Got data ", string(msg.Value))
 				var kafkaData KafkaData
 				json.Unmarshal(msg.Value, &kafkaData)
 
-				// fmt.Println("Lat: " + kafkaData.Latitude + " Lng: " + kafkaData.Longitude)
 				// Check if ClientID exists
-				//.RLock()
+				mutex.Lock()
 				if _, contains := clientConnections[kafkaData.ClientID]; contains {
 					// If client is connected, get map of connections
 					clientConnections := clientConnections[kafkaData.ClientID]
 					//iterate over client connections
 					for conn, _ := range clientConnections {
+						//TODO Update allFilters if find a new filter and send new filter options to front end
 						//if connection filter has KafkaData eventID, send data
-						// if _, hasEvent := conn.filterSetting[kafkaData.EventID]; hasEvent {
-						conn.ws.WriteJSON(kafkaData)
-						fmt.Println(kafkaData)
-						//fmt.Println("Send Data to ", conn.clientID)
-						// }
+						if _, hasEvent := conn.filter[kafkaData.EventID]; hasEvent {
+							conn.ws.WriteJSON(kafkaData)
+						}
 					}
 				}
-				//.Unlock()
+				mutex.Unlock()
 			// Service interruption
 			case <-signals:
 				fmt.Println("Interrupt detected")
 				doneCh <- struct{}{}
-				break
+				break Loop
 			}
 		}
 	}()


### PR DESCRIPTION
This API enables multi-client functionality, multi-node functionality for one client, filters requests based on clients input, consumes data from Kafka and sends based on clientID and connection filter settings.

to test:

-set up backend api according to its ReadMe in their own terminals (needs 2)
-then run "go run cmd/doppler-api/main.go" in its own terminal
-then set up frontend according to its ReadMe (I dont think that ReadMe is up to date, so download current master, then run "static-server", then open on localhost:9080) 
-log in as "client0" or "nav1"
-see data points in console