### PR TITLE
fixed excessive cpu usage

### DIFF
--- a/internal/liveupdate/liveupdate.go
+++ b/internal/liveupdate/liveupdate.go
@@ -382,6 +382,8 @@ func closeConnection(conn *ConnWithParameters) {
 func intervalFlush() {
 	//initialize time of flush
 	var flushTime time.Time
+	// time to wait so that data can be added to batches
+	delay := (batchInterval * time.Millisecond / 100) * time.Microsecond
 	//continuously check if need to flush because of time interval
 	for {
 		// check to see if any clients are connected
@@ -404,6 +406,7 @@ func intervalFlush() {
 			}
 		}
 		mutex.Unlock()
+		time.Sleep(delay) // used to allow for data to get into the batches
 	}
 }
 

--- a/internal/liveupdate/liveupdate.go
+++ b/internal/liveupdate/liveupdate.go
@@ -358,7 +358,6 @@ func initConn(conn *ConnWithParameters, message msg) (*ConnWithParameters, bool)
 	//start checking if need to flush batch but iff no other checking has started because
 	// this takes a lot of CPU
 	if len(clientConnections) == 1 {
-		fmt.Println("Started CPU massacre!")
 		go intervalFlush()
 	}
 
@@ -387,7 +386,6 @@ func intervalFlush() {
 	for {
 		// check to see if any clients are connected
 		if len(clientConnections) == 0 { // no clients are connected, so free up the CPU
-			fmt.Println("Ended CPU massacre!")
 			return
 		}
 		mutex.Lock()                              // make sure that nothing writes to the map while it is being looked at


### PR DESCRIPTION
The internalFlush function now checks the flush for all websocket connections and only does so if there is at least one client connected. If all clients have disconnected, the function terminates until the first client connects again.
Fixes #44  
Makes the CPU stay at roughly the same CPU regardless of how many clients have/are connected to the server.
Test: use activity monitor for cpu checking (make sure to look at system and user for the calculations)
1. Start up the doppler API and watch it for a minute to get the base line cpu usage for the program.
2. Next start the frontend API and do the same.
3. Then connect a client, but DO NOT enter an ID. Check the cpu usage: it should be around the baseline.
4. Next enter an ID and check the activity monitor. The cpu usage should be around twice the baseline(wait 1 minute then drop that connection and create a new one repeating steps 3 and 4)[after doing this once or twice stop].
