### PR TITLE
bind influx query parameters && take seconds from frontend

### DIFF
--- a/internal/service/influxDB.go
+++ b/internal/service/influxDB.go
@@ -25,8 +25,8 @@ type InfluxService struct {
 type request struct {
 	clientID  string   // clientID of ajax request
 	events    []string // slice of event filters
-	startTime string   // Unix start time
-	endTime   string   // Unix end time
+	startTime int      // Unix start time
+	endTime   int      // Unix end time
 	index     string   // the index of the ajax request
 
 	truncateSize int    // int uesd to determine how much points are truncated during bucketing
@@ -59,7 +59,7 @@ func (c *InfluxService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println("New Request Error: ", err)
 		w.WriteHeader(http.StatusBadRequest)
-		_, err := w.Write([]byte(err.Error()))
+		_, err = w.Write([]byte(err.Error()))
 		if err != nil {
 			log.Println("Write AJAX Response Error Error: ", err)
 		}
@@ -130,17 +130,27 @@ func (c *InfluxService) newRequest(requestQuery url.Values) (*request, error) {
 		return &request{}, err
 	}
 	// get startTime
-	startTime := requestQuery["startTime"][0] // get startTime (index zero since only have one ID)
+	stringSec := requestQuery["startTime"][0] // get startTime as string of seconds (index zero since only have one ID)
+	secs, err := strconv.Atoi(stringSec)      // convert string to int
+	if err != nil {
+		log.Println("Parse Start Time Error: ", err)
+	}
+	startTime := secs / 1000000000 // convert seconds to nanoseconds
 
 	// get end time
 	// check if request contains end time
 	_, contains = requestQuery["endTime"]
 	if !contains {
-		err := errors.New("Request Missing End Time")
+		err = errors.New("Request Missing End Time")
 		return &request{}, err
 	}
 	// get endTime
-	endTime := requestQuery["endTime"][0] // get endTime (index zero since only have one ID)
+	stringSec = requestQuery["endTime"][0] // get endTime as string of seconds (index zero since only have one ID)
+	secs, err = strconv.Atoi(stringSec)    // convert string to int
+	if err != nil {
+		log.Println("Parse Start Time Error: ", err)
+	}
+	endTime := secs / 1000000000 // convert seconds to nanoseconds
 
 	// get the ajax index
 	// check if request contains index
@@ -178,21 +188,11 @@ func (c *InfluxService) queryInfluxDB(request *request) ([]Point, error) {
 	// initialize query string without events
 	q := "SELECT lat,lng FROM dopplerDataHistory WHERE time >= $startTime AND time <= $endTime AND clientID = $clientID AND ("
 
-	// convert string of time to int of time for influx (gives error otherwise)
-	sTime, err := strconv.Atoi(request.startTime)
-	if err != nil {
-		fmt.Println("sTime strconv Error: ", err)
-	}
-	eTime, err := strconv.Atoi(request.endTime)
-	if err != nil {
-		fmt.Println("eTime strconv Error: ", err)
-	}
-
 	// initialize parameters without events
 	parameters := map[string]interface{}{
-		"startTime": sTime,            // time as int
-		"endTime":   eTime,            // time as int
-		"clientID":  request.clientID, // clientID as string
+		"startTime": request.startTime, // time as int
+		"endTime":   request.endTime,   // time as int
+		"clientID":  request.clientID,  // clientID as string
 	}
 
 	// add eventID statements to query string


### PR DESCRIPTION
Updated InfluxDB query creation to prevent SQL injections
Updated newRequest to handle seconds from doppler-frontend

Injection Testing:

Use either Postman or browser for test (or update doppler-frontend to send URLs below, but that would be a lot of work). 

Doppler-api must be running. 

Need "rest" event or need to update URL to an event that you have in InfluxDB to verify results

Use the following URLs for the tests below:
Clean URL:
http://localhost:8000/receive/ajax?clientID=client1&endTime=1531281600000000000&index=0&startTime=1531195200000000000&filters[]=rest

Injection URL:
http://localhost:8000/receive/ajax?clientID=client1&endTime=1531281600000000000&index=0&startTime=1531195200000000000&filters[]=rest&filters[]=(SELECT COUNT(*) FROM dopplerDataHistory)

On doppler-api master branch:
- first send Clean URL to api (in Postman or paste URL into browser)
- verify received points and no errors in api logs
- send Injection URL to api
- see that no points are received and that there is an error in api logs
- error indicates that InfluxDB attempted to execute the "SELECT COUNT(*)..." filter as a command

On dopper-api matts/sanitize branch:
- first send Clean URL to api (in Postman or paste URL into browser)
- verify received points and no errors in api logs
- send Injection URL to api
- see that points are still received and that there are still no errors in api logs
- no errors indicates that InfluxDB attempted to evaluate the "SELECT COUNT(*)..." filter as an event rather than attempt to execute it as a command.

fixes #69 
fixes #73 